### PR TITLE
Use the new url for the tracker

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -96,7 +96,7 @@ activate :directory_indexes
 
 activate :piwik do |f|
     f.id = 3
-    f.domain = 'piwik-osasteam.rhcloud.com'
+    f.domain = 'tracker.osci.io'
     f.url = 'piwik'
 end
 


### PR DESCRIPTION
Since we are moving it out of openshift, we need to use another name