### PR TITLE
disable commenting

### DIFF
--- a/data/site.yml
+++ b/data/site.yml
@@ -3,7 +3,7 @@ subhead: Open Source Community
 domain: community.redhat.com
 
 # Be sure to set up and install Juvia before enabling!
-#has_comments: true
+#has_comments: false
 
 # Optional logo. If commented out, it will not be used.
 logo: logo.svg


### PR DESCRIPTION
The commenting system used by this site has been unmaintained for three years now, and the hosting of the current instance will soon be disrupted by the sunsetting of openshift online v2. This PR disables commenting for now.