### PR TITLE
add GNOME Boxes to the software/desktop list

### DIFF
--- a/data/software.yml
+++ b/data/software.yml
@@ -421,6 +421,9 @@ Desktop:
   - name: Gnome-user-share
     url: http://git.gnome.org/browse/gnome-user-share/
 
+  - name: GNOME Boxs
+    url: https://wiki.gnome.org/Apps/Boxes
+
   - name: GTK+
     url: http://www.gtk.org/
 

--- a/data/software.yml
+++ b/data/software.yml
@@ -421,7 +421,7 @@ Desktop:
   - name: Gnome-user-share
     url: http://git.gnome.org/browse/gnome-user-share/
 
-  - name: GNOME Boxs
+  - name: GNOME Boxes
     url: https://wiki.gnome.org/Apps/Boxes
 
   - name: GTK+


### PR DESCRIPTION
I am a Red Hatter working full time in GNOME Boxes. It would make me really happy to see our project listed alongside our other desktop components.